### PR TITLE
builds irl as shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,9 @@ if(BUILD_SHARED_LIBS)
   add_library(irl SHARED)
   add_library(irl_c SHARED)
   add_library(irl_fortran SHARED)
+  if(APPLE AND IRL_USE_ABSL)
+    target_link_libraries(irl PUBLIC "-framework CoreFoundation")
+  endif()
 else()
   add_library(irl STATIC)
   add_library(irl_c STATIC)
@@ -122,7 +125,7 @@ add_subdirectory("${PROJECT_SOURCE_DIR}/examples")
 #add_subdirectory("${PROJECT_SOURCE_DIR}/tools")
 
 # Export targets to be used by other programs
-install(TARGETS irl EXPORT "irl_exp" ARCHIVE DESTINATION "./lib")
+install(TARGETS irl EXPORT "irl_exp" ARCHIVE DESTINATION "lib")
 install(DIRECTORY "${CMAKE_SOURCE_DIR}/irl" # source directory
         DESTINATION "include" # target directory
         FILES_MATCHING # install only matched files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,9 +77,15 @@ endif()
 set( CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod )
 
 # Add IRL Libraries that we are creating
-add_library(irl STATIC)
-add_library(irl_c STATIC)
-add_library(irl_fortran STATIC)
+if(BUILD_SHARED_LIBS)
+  add_library(irl SHARED)
+  add_library(irl_c SHARED)
+  add_library(irl_fortran SHARED)
+else()
+  add_library(irl STATIC)
+  add_library(irl_c STATIC)
+  add_library(irl_fortran STATIC)
+endif()
 
 # C++ IRL Base
 target_include_directories(irl PUBLIC "${PROJECT_SOURCE_DIR}")

--- a/docs/markdown/install_main_page.md
+++ b/docs/markdown/install_main_page.md
@@ -18,6 +18,7 @@ Several additional options can be passed to the CMake configuration to tailor IR
 * `-D BUILD_TESTING=ON` ----- Turns on building of unit tests, which are not built by default.  If building tests, GoogleTest will be downloaded and compiled unless the GOOGLETEST_DIR CMake flag is given. 
 * `-D GOOGLETEST_DIR=/path/to/google_test` ----- Provides path to [Google Test](https://github.com/google/googletest) that will be used if when building tests (if turned on).
 * `-D USE_ABSL=OFF` ----- IRL ships with a version of [Google Abseil](https://github.com/abseil/abseil-cpp) for use of its `inlined_vector` and `flat_hash_map` classes. By turning it off, IRL will revert back to its own implementation. This is strongly discouraged for performance reasons.
+* `-D BUILD_SHARED_LIBS=TRUE` ----- Build IRL as a shared library
 
 
 ## External Dependencies

--- a/external/abseil-cpp/CMakeLists.txt
+++ b/external/abseil-cpp/CMakeLists.txt
@@ -111,13 +111,16 @@ endif()
 
 if(BUILD_SHARED_LIBS)
   add_library(absl_all SHARED)
+  if(APPLE)
+    target_link_libraries(absl_all "-framework CoreFoundation")
+  endif()
 else()
   add_library(absl_all STATIC)
 endif()
 
 target_include_directories(absl_all PUBLIC ".")
 add_subdirectory(absl)
-install(TARGETS absl_all EXPORT "absl_all_exp" ARCHIVE DESTINATION "./absl/lib")
+install(TARGETS absl_all EXPORT "absl_all_exp" ARCHIVE DESTINATION "lib")
 
 if(ABSL_ENABLE_INSTALL)
   # absl:lts-remove-begin(system installation is supported for LTS releases)

--- a/external/abseil-cpp/CMakeLists.txt
+++ b/external/abseil-cpp/CMakeLists.txt
@@ -109,7 +109,12 @@ if(BUILD_TESTING)
   )
 endif()
 
-add_library(absl_all STATIC)
+if(BUILD_SHARED_LIBS)
+  add_library(absl_all SHARED)
+else()
+  add_library(absl_all STATIC)
+endif()
+
 target_include_directories(absl_all PUBLIC ".")
 add_subdirectory(absl)
 install(TARGETS absl_all EXPORT "absl_all_exp" ARCHIVE DESTINATION "./absl/lib")


### PR DESCRIPTION
allow build irl as shared library using -D BUILD_SHARED_LIBS=TRUE flag. Doesn't change static build. All examples were compiled and seems to work with shared version as well