### PR TITLE
Add spack capability for IRL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,20 +74,26 @@ if(IRL_USE_ABSL)
 endif()
 
 # Path for Fortran Module files
+if(IRL_BUILD_FORTRAN)
 set( CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod )
+endif()
 
 # Add IRL Libraries that we are creating
 if(BUILD_SHARED_LIBS)
   add_library(irl SHARED)
-  add_library(irl_c SHARED)
-  add_library(irl_fortran SHARED)
+  if(IRL_BUILD_FORTRAN)
+    add_library(irl_c SHARED)
+    add_library(irl_fortran SHARED)
+  endif()
   if(APPLE AND IRL_USE_ABSL)
     target_link_libraries(irl PUBLIC "-framework CoreFoundation")
   endif()
 else()
   add_library(irl STATIC)
-  add_library(irl_c STATIC)
-  add_library(irl_fortran STATIC)
+  if(IRL_BUILD_FORTRAN)
+    add_library(irl_c STATIC)
+    add_library(irl_fortran STATIC)
+  endif()
 endif()
 
 # C++ IRL Base
@@ -98,11 +104,13 @@ if(IRL_USE_ABSL)
   target_link_libraries(irl PUBLIC absl::inlined_vector absl::flat_hash_map)
 endif()
 
-# C Interface
-target_link_libraries(irl_c PUBLIC irl)
+if(IRL_BUILD_FORTRAN)
+  # C Interface
+  target_link_libraries(irl_c PUBLIC irl)
 
-# Fortran Interface
-target_link_libraries(irl_fortran PUBLIC irl_c)
+  # Fortran Interface
+  target_link_libraries(irl_fortran PUBLIC irl_c)
+endif()
 
 
 # Directory for test files
@@ -146,6 +154,9 @@ install(DIRECTORY "${CMAKE_SOURCE_DIR}/external/abseil-cpp" # source directory
         FILES_MATCHING # install only matched files
         PATTERN "*.inc"# select header files
 )
-install(TARGETS irl_c EXPORT "irl_c_exp" ARCHIVE DESTINATION "lib")
-install(TARGETS irl_fortran EXPORT "irl_fortran_exp" ARCHIVE DESTINATION "lib")
-install(DIRECTORY "${CMAKE_Fortran_MODULE_DIRECTORY}/" DESTINATION "include/irl_fortran")
+
+if(IRL_BUILD_FORTRAN)
+  install(TARGETS irl_c EXPORT "irl_c_exp" ARCHIVE DESTINATION "lib")
+  install(TARGETS irl_fortran EXPORT "irl_fortran_exp" ARCHIVE DESTINATION "lib")
+  install(DIRECTORY "${CMAKE_Fortran_MODULE_DIRECTORY}/" DESTINATION "include/irl_fortran")
+endif()

--- a/spack-repo/packages/irl/package.py
+++ b/spack-repo/packages/irl/package.py
@@ -1,0 +1,57 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install irl
+#
+# You can edit this file again by typing:
+#
+#     spack edit irl
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack.package import *
+
+
+class Irl(CMakePackage):
+    """Interface Reconstruction Library with computational geometry algorithms used in 
+       geometric VOF and ALE remapping schemes, among others.    
+    """
+
+    homepage = "https://github.com/robert-chiodi/interface-reconstruction-library"
+    git      = "https://github.com/robert-chiodi/interface-reconstruction-library.git"
+
+    # Versions
+    version('develop', branch='master', submodules=False, preferred=True)
+
+    # Github accounts to notify of package changes
+    maintainers = ['robert-chiodi']
+
+    # Variants
+    variant('unit', default=False,
+            description='Enable Unit Tests')    
+    variant('absl', default=True,
+            description='Use ABSL for some underlying classes')            
+    variant('fort_lib', default=False,
+            description='Build Fortran library interface')
+
+    # Dependencies
+    depends_on('cmake', type='build')    
+    depends_on('eigen')
+
+    def cmake_args(self):
+        return [
+            self.define_from_variant('BUILD_TESTING', 'unit'),
+            self.define_from_variant('IRL_USE_ABSL', 'absl'),
+            self.define_from_variant('IRL_BUILD_FORTRAN', 'fort_lib')
+        ]

--- a/spack-repo/repo.yaml
+++ b/spack-repo/repo.yaml
@@ -1,0 +1,2 @@
+repo:
+  namespace: 'irl'


### PR DESCRIPTION
Add spack use for IRL and some variants to control if unit tests are built, if abseil is used, and if the fortran interface is needed.