### PR TITLE
Correct Optional Building of Fortran Interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ endif()
 
 if(IRL_USE_ABSL)
   # Add Abseil as a sub-directory but temporarily turn testing off.
+  set(ABSL_PROPAGATE_CXX_STD ON)
   set(ABSEIL_DIR "${PROJECT_SOURCE_DIR}/external/abseil-cpp")
   set(BUILD_TESTING_ORIG ${BUILD_TESTING})
   set(BUILD_TESTING OFF)
@@ -74,26 +75,20 @@ if(IRL_USE_ABSL)
 endif()
 
 # Path for Fortran Module files
-if(IRL_BUILD_FORTRAN)
-set( CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod )
-endif()
+set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod )
 
 # Add IRL Libraries that we are creating
 if(BUILD_SHARED_LIBS)
   add_library(irl SHARED)
-  if(IRL_BUILD_FORTRAN)
-    add_library(irl_c SHARED)
-    add_library(irl_fortran SHARED)
-  endif()
+  add_library(irl_c SHARED)
+  add_library(irl_fortran SHARED)
   if(APPLE AND IRL_USE_ABSL)
     target_link_libraries(irl PUBLIC "-framework CoreFoundation")
   endif()
 else()
   add_library(irl STATIC)
-  if(IRL_BUILD_FORTRAN)
-    add_library(irl_c STATIC)
-    add_library(irl_fortran STATIC)
-  endif()
+  add_library(irl_c STATIC)
+  add_library(irl_fortran STATIC)
 endif()
 
 # C++ IRL Base
@@ -104,14 +99,16 @@ if(IRL_USE_ABSL)
   target_link_libraries(irl PUBLIC absl::inlined_vector absl::flat_hash_map)
 endif()
 
-if(IRL_BUILD_FORTRAN)
-  # C Interface
-  target_link_libraries(irl_c PUBLIC irl)
+# C Interface
+target_link_libraries(irl_c PUBLIC irl)
 
-  # Fortran Interface
-  target_link_libraries(irl_fortran PUBLIC irl_c)
+# Fortran Interface
+target_link_libraries(irl_fortran PUBLIC irl_c)
+
+if(NOT IRL_BUILD_FORTRAN)
+  set_target_properties(irl_c irl_fortran 
+			PROPERTIES EXCLUDE_FROM_ALL TRUE)
 endif()
-
 
 # Directory for test files
 # Will automatically download GoogleTest and compile it to

--- a/docs/markdown/install_main_page.md
+++ b/docs/markdown/install_main_page.md
@@ -2,24 +2,28 @@
 
 IRL uses CMake (version >= 3.9) to handle its configuration and compilation. By default, the IRL C++, C, and Fortran interfaces will be built. The install directory can be modified in typical cmake fashion by defining `-D CMAKE_INSTALL_PREFIX=install_directory`.
 After installing the dependencies (detailed below), the simplest IRL CMake build command can be executed as
+
 ```
 mkdir build &&
 cd build &&
 cmake .. &&
 make install
 ```
-The path to Eigen (a required dependency) can be given through the CMake variable `-D EIGEN_DIR=path/to/Eigen`.  If not supplied, Eigen will be searched for in the CMake default locations, such as `/usr/include`.
+
+The path to Eigen (a required dependency) can be given through the CMake variable `-D EIGEN_DIR=path/to/Eigen`. If not supplied, Eigen will be searched for in the CMake default locations, such as `/usr/include`, or paths specified by `CMAKE_PREFIX_PATH`.
 
 To change the compiler or compiler options, change the environment variables `CXX` and `FC` for C++ and Fortran, respectively. The compiler flags can also be changed via the environment variables `CXXFLAGS` and `FFLAGS`. As opposed to settign the environment variables, the above information can also be supplied via the CMake variables `CMAKE_CXX_COMPILER`, `CMAKE_Fortran_COMPILER`, `CMAKE_CXX_FLAGS`, and `CMAKE_Fortran_FLAGS`. Note: If the `CMAKE_BUILD_TYPE` is not `Debug`, the compiler flags `-DNDEBUG` and `-DNDEBUG_PERF` will be appended to `CMAKE_CXX_FLAGS`. The default value for `CMAKE_BUILD_TYPE` is `Release` if one is not supplied.
 
+By default, the Fortran library interface is not built. To enable this, supply `-D IRL_BUILD_FORTRAN=ON` when configuring CMake.
+
 Several additional options can be passed to the CMake configuration to tailor IRL to your needs. They are described below.
 
-* `-D EIGEN_DIR=/path/to/Eigen` ----- Provides path to Eigen directory.
-* `-D BUILD_TESTING=ON` ----- Turns on building of unit tests, which are not built by default.  If building tests, GoogleTest will be downloaded and compiled unless the GOOGLETEST_DIR CMake flag is given. 
-* `-D GOOGLETEST_DIR=/path/to/google_test` ----- Provides path to [Google Test](https://github.com/google/googletest) that will be used if when building tests (if turned on).
-* `-D USE_ABSL=OFF` ----- IRL ships with a version of [Google Abseil](https://github.com/abseil/abseil-cpp) for use of its `inlined_vector` and `flat_hash_map` classes. By turning it off, IRL will revert back to its own implementation. This is strongly discouraged for performance reasons.
-* `-D BUILD_SHARED_LIBS=TRUE` ----- Build IRL as a shared library
-
+- `-D EIGEN_DIR=/path/to/Eigen` ----- Provides path to Eigen directory.
+- `-D BUILD_TESTING=ON` ----- Turns on building of unit tests, which are not built by default. If building tests, GoogleTest will be downloaded and compiled unless the GOOGLETEST_DIR CMake flag is given.
+- `-D GOOGLETEST_DIR=/path/to/google_test` ----- Provides path to [Google Test](https://github.com/google/googletest) that will be used if when building tests (if turned on).
+- `-D IRL_BUILD_FORTRAN=ON` ----- Results in the IRL Fortran and C interfaces being built and installed.
+- `-D IRL_USE_ABSL=OFF` ----- IRL ships with a version of [Google Abseil](https://github.com/abseil/abseil-cpp) for use of its `inlined_vector` and `flat_hash_map` classes. By turning it off, IRL will revert back to its own implementation. This is strongly discouraged for performance reasons.
+- `-D BUILD_SHARED_LIBS=TRUE` ----- Build IRL as a shared library
 
 ## External Dependencies
 

--- a/spack-repo/packages/irl/package.py
+++ b/spack-repo/packages/irl/package.py
@@ -42,7 +42,7 @@ class Irl(CMakePackage):
             description='Enable Unit Tests')    
     variant('absl', default=True,
             description='Use ABSL for some underlying classes')            
-    variant('fort_lib', default=False,
+    variant('fortran', default=False,
             description='Build Fortran library interface')
 
     # Dependencies
@@ -53,5 +53,5 @@ class Irl(CMakePackage):
         return [
             self.define_from_variant('BUILD_TESTING', 'unit'),
             self.define_from_variant('IRL_USE_ABSL', 'absl'),
-            self.define_from_variant('IRL_BUILD_FORTRAN', 'fort_lib')
+            self.define_from_variant('IRL_BUILD_FORTRAN', 'fortran')
         ]


### PR DESCRIPTION
Fortran interface now defaults to being **not** built. Need to enable with `-D IRL_BUILD_FORTRAN` during CMake configure step.