### PR TITLE
Add Volume header file

### DIFF
--- a/irl/moments/general_moments.h
+++ b/irl/moments/general_moments.h
@@ -12,6 +12,7 @@
 
 #include <ostream>
 
+#include "irl/moments/volume.h"
 #include "irl/parameters/defined_types.h"
 
 namespace IRL {


### PR DESCRIPTION
This includes the `irl/moments/volume.h` header for GeneralMoments to fix compilation problems.