### PR TITLE
Fixed issues with IRL and R2P

### DIFF
--- a/irl/generic_cutting/cut_polygon.tpp
+++ b/irl/generic_cutting/cut_polygon.tpp
@@ -302,7 +302,7 @@ void cutPolygonByPlaneInPlace(PolygonType* a_polygon,
   double distance_to_vertex_after_second_intersection =
       getIntersectionPts(*a_polygon, a_cutting_plane, a_flip_cut,
                          &intersection_pts, &index_after_intersection);
-  if (intersection_pts.size() == 0) {
+  if (intersection_pts.size() < 2) {
     // No intersection with plane, distance to any point will tell us if fully
     // under or over plane
     if (distance_to_vertex_after_second_intersection <= 0.0) {

--- a/irl/generic_cutting/cut_polygon.tpp
+++ b/irl/generic_cutting/cut_polygon.tpp
@@ -302,6 +302,8 @@ void cutPolygonByPlaneInPlace(PolygonType* a_polygon,
   double distance_to_vertex_after_second_intersection =
       getIntersectionPts(*a_polygon, a_cutting_plane, a_flip_cut,
                          &intersection_pts, &index_after_intersection);
+  // We check that we have 2 intersections, as floating point can lead to a single intersection detected
+  // for cases where the plane is almost coincident with the polygon.
   if (intersection_pts.size() < 2) {
     // No intersection with plane, distance to any point will tell us if fully
     // under or over plane

--- a/irl/geometry/half_edge_structures/half_edge_polytope.h
+++ b/irl/geometry/half_edge_structures/half_edge_polytope.h
@@ -171,7 +171,7 @@ private:
 
 namespace half_edge_polytope {
 namespace default_sizes {
-static constexpr UnsignedIndex_t complete_block_vertices = 64;
+static constexpr UnsignedIndex_t complete_block_vertices = 128;
 static constexpr UnsignedIndex_t complete_block_faces = 32;
 static constexpr UnsignedIndex_t complete_block_half_edges = 128;
 } // namespace default_sizes

--- a/irl/geometry/half_edge_structures/segmented_half_edge_polytope.h
+++ b/irl/geometry/half_edge_structures/segmented_half_edge_polytope.h
@@ -21,7 +21,7 @@ namespace IRL {
 namespace segmented_half_edge_polytope {
 namespace default_sizes {
 static constexpr UnsignedIndex_t segemented_max_faces = 64;
-static constexpr UnsignedIndex_t segmented_max_vertices = 64;
+static constexpr UnsignedIndex_t segmented_max_vertices = 128;
 }  // namespace default_sizes
 }  // namespace segmented_half_edge_polytope
 

--- a/irl/interface_reconstruction_methods/r2p_optimization.tpp
+++ b/irl/interface_reconstruction_methods/r2p_optimization.tpp
@@ -1014,9 +1014,9 @@ PlanarSeparator R2P_3D2P<CellType>::getReconstructionFromR2PParam(
   setDistanceToMatchVolumeFractionPartialFill(this->system_center_cell_m,
                                               this->volume_fraction_m,
                                               &reconstruction_to_return);
-  cleanReconstructionSameNormal(this->system_center_cell_m,
-                                this->volume_fraction_m,
-                                &reconstruction_to_return);
+  // cleanReconstructionSameNormal(this->system_center_cell_m,
+  //                               this->volume_fraction_m,
+  //                               &reconstruction_to_return);
   return reconstruction_to_return;
 }
 

--- a/irl/interface_reconstruction_methods/r2p_optimization.tpp
+++ b/irl/interface_reconstruction_methods/r2p_optimization.tpp
@@ -1014,9 +1014,6 @@ PlanarSeparator R2P_3D2P<CellType>::getReconstructionFromR2PParam(
   setDistanceToMatchVolumeFractionPartialFill(this->system_center_cell_m,
                                               this->volume_fraction_m,
                                               &reconstruction_to_return);
-  // cleanReconstructionSameNormal(this->system_center_cell_m,
-  //                               this->volume_fraction_m,
-  //                               &reconstruction_to_return);
   return reconstruction_to_return;
 }
 


### PR DESCRIPTION
These fixes address memory issues that occur when R2P converges two planes onto a single plane and when only one intersection is returned. Additionally, this update allocates extra memory to avoid dynamic array allocations during R2P usage.